### PR TITLE
Add Brio 501 to known Logitech Brio devices

### DIFF
--- a/cameractrls.py
+++ b/cameractrls.py
@@ -1119,6 +1119,7 @@ LOGITECH_BRIO_GUID = b'\x15\x02\xe4\x49\x34\xf4\xfe\x47\xb1\x58\x0e\x88\x50\x23\
 LOGITECH_BRIO_FOV_DEV_MATCH = [
     '046d:085e', # Brio
     '046d:0943', # Brio 500
+    '046d:0946', # Brio 501
     '046d:086b', # Brio 4K Stream Edition
 ]
 LOGITECH_BRIO_FOV_SEL = 0x05


### PR DESCRIPTION
Recently got a Brio 501, noticed that this was one of the only apps that actually supported the additional features some of these cameras have (effectively emulating Logi Tune or whatever). However, my camera being a _501_ rather than a _500_ meant that the FOV feature wasn't supported. I edited the `LOGITECH_BRIO_FOV_DEV_MATCH` variable to include my camera and everything seems to work fine - I can change FOV and everything works.

![image](https://user-images.githubusercontent.com/34875062/228425887-7bca1008-68dd-4d44-919a-8d912fa96f7b.png)
