### PR TITLE
Fix config location when XDG_CONFIG_DIR is set

### DIFF
--- a/cameractrls.py
+++ b/cameractrls.py
@@ -2450,7 +2450,8 @@ def find_symlink_in(dir, paths):
     return None
 
 def get_configdir():
-    return os.getenv("XDG_CONFIG_HOME", os.path.expanduser('~/.config/hu.irl.cameractrls'))
+    config_dir_base = os.path.expanduser(os.getenv("XDG_CONFIG_HOME", '~/.config'))
+    return os.path.join(config_dir_base, 'hu.irl.cameractrls')
 
 def get_configfilename(device):
     if device.startswith('/dev/video'):


### PR DESCRIPTION
Resolve the issue where, if `XDG_CONFIG_DIR` is set in the environment, we store files directly there rather than in a subdirectory of that directory (as is intended). Also ensure that we `expanduser` the `XDG_CONFIG_DIR` value just in case.

This patch doesn't add migrating the user's current presets from `XDG_CONFIG_DIR`, but if that would be useful (it probably would be) I can implement that as well.