### PR TITLE
Detect readonly controls and disable in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+ - Gray out the readonly controls
+
 ## [0.6.4] - 2024-05-28
 
 ### Fixed

--- a/cameractrlsgtk.py
+++ b/cameractrlsgtk.py
@@ -522,9 +522,9 @@ class CameraCtrlsWindow(Gtk.ApplicationWindow):
 
     def update_ctrl_state(self, c):
         for gui_ctrl in c.gui_ctrls:
-            gui_ctrl.set_sensitive(not c.inactive)
+            gui_ctrl.set_sensitive(not c.inactive and not c.readonly)
         if c.gui_default_btn is not None:
-            visible = not c.inactive and (
+            visible = not c.inactive and not c.readonly and (
                 c.default is not None and c.value is not None and c.default != c.value or \
                 c.get_default is not None and not c.get_default()
             )

--- a/cameractrlsgtk4.py
+++ b/cameractrlsgtk4.py
@@ -516,9 +516,9 @@ class CameraCtrlsWindow(Gtk.ApplicationWindow):
 
     def update_ctrl_state(self, c):
         for gui_ctrl in c.gui_ctrls:
-            gui_ctrl.set_sensitive(not c.inactive)
+            gui_ctrl.set_sensitive(not c.inactive and not c.readonly)
         if c.gui_default_btn is not None:
-            visible = not c.inactive and (
+            visible = not c.inactive and not c.readonly and (
                 c.default is not None and c.value is not None and c.default != c.value or \
                 c.get_default is not None and not c.get_default()
             )


### PR DESCRIPTION
Readonly controls can only be set by the camera and read by the driver and application.

Currently though the kernel doesn't propagate the flag properly to userspace. I'm in the process of submitting it upstream.