### PR TITLE
Fix readonly condition

### DIFF
--- a/cameractrls.py
+++ b/cameractrls.py
@@ -2413,7 +2413,7 @@ class ConfigPreset:
         return {
             c.text_id: c.value
             for c in self.cam_ctrls.get_ctrls()
-            if not c.inactive and not readonly and c.value is not None and c.type != 'info' and not c.unrestorable
+            if not c.inactive and not c.readonly and c.value is not None and c.type != 'info' and not c.unrestorable
         }
 
     def load_preset(self, device, preset_num, errs):


### PR DESCRIPTION
Fixes typo, which prevents from saving any config
![image](https://github.com/soyersoyer/cameractrls/assets/39561451/fcc61953-d511-40d7-882f-3b83f1235307)
