### PR TITLE
cameractrls: iterate over control IDs in cases where device driver does not return the next higher control ID on error

### DIFF
--- a/cameractrls.py
+++ b/cameractrls.py
@@ -2190,9 +2190,7 @@ class V4L2Ctrls:
                 ioctl(self.fd, VIDIOC_QUERYCTRL, qctrl)
             except OSError as err:
                 if err.errno == EIO:
-                    logging.warning(f'The driver behind device {self.device} has a slightly buggy implementation '
-                    'of the V4L2_CTRL_FLAG_NEXT_CTRL flag. It does not return the next higher '
-                    'control ID if a control query fails. A workaround has been enabled.')
+                    logging.warning(f'V4L2Ctrls: VIDIOC_QUERYCTL returned EIO for {self.to_text_id(qctrl.name)}. Skipping...')
                     qctrl = v4l2_queryctrl(qctrl.id + 1 | next_flag)
                     continue
                 else:


### PR DESCRIPTION
This is ported over from [libwebcam](https://sourceforge.net/p/libwebcam/code/ci/master/tree/libwebcam/libwebcam.c#l1982) which was able to correctly return controls when cameractrls couldn't. libwebcam is licensed under GPL3.

Recently got a new microscope webcam which had various options available from its OSC (which would only display if using its HDMI output). `lsusb -v` showed it had extensions available, but various camera tools would not display them except for `uvcdynctrl` from libwebcam. However I much prefer using cameractrls so I tried to port over the functionality.

Apologies if the preferred solution would be to add a specific class for the controls, but this was sufficient for my usecase.

I was unsure about formatting so I made my best effort. Implementation wise it's a little messy and I'm open to clean up suggestions.